### PR TITLE
pkg/sql: SQL metrics with app_name and db_name labels

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -579,6 +579,7 @@ go_library(
         "//pkg/util/memzipper",
         "//pkg/util/metamorphic",
         "//pkg/util/metric",
+        "//pkg/util/metric/aggmetric",
         "//pkg/util/mon",
         "//pkg/util/optional",
         "//pkg/util/pretty",

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -22,11 +22,11 @@ import (
 // EngineMetrics groups a set of SQL metrics.
 type EngineMetrics struct {
 	// The subset of SELECTs that are requested to be processed through DistSQL.
-	DistSQLSelectCount *metric.Counter
+	DistSQLSelectCount *SQLCounter
 	// The subset of SELECTs that were executed by DistSQL with full or partial
 	// distribution.
 	DistSQLSelectDistributedCount *metric.Counter
-	SQLOptPlanCacheHits           *metric.Counter
+	SQLOptPlanCacheHits           *SQLCounter
 	SQLOptPlanCacheMisses         *metric.Counter
 	StatementFingerprintCount     *metric.UniqueCounter
 
@@ -301,7 +301,8 @@ func (ex *connExecutor) recordStatementLatencyMetrics(
 
 		if flags.ShouldBeDistributed() {
 			if _, ok := stmt.AST.(*tree.Select); ok {
-				m.DistSQLSelectCount.Inc(1)
+				m.DistSQLSelectCount.Inc(ex.sessionData().Database, ex.sessionData().ApplicationName)
+
 				if flags.IsSet(planFlagDistributedExecution) {
 					m.DistSQLSelectDistributedCount.Inc(1)
 				}
@@ -328,7 +329,7 @@ func (ex *connExecutor) updateOptCounters(planFlags planFlags) {
 	m := &ex.metrics.EngineMetrics
 
 	if planFlags.IsSet(planFlagOptCacheHit) {
-		m.SQLOptPlanCacheHits.Inc(1)
+		m.SQLOptPlanCacheHits.Inc(ex.sessionData().Database, ex.sessionData().ApplicationName)
 	} else if planFlags.IsSet(planFlagOptCacheMiss) {
 		m.SQLOptPlanCacheMisses.Inc(1)
 	}

--- a/pkg/sql/testdata/sql_counter
+++ b/pkg/sql/testdata/sql_counter
@@ -1,0 +1,22 @@
+sql_counter appName=test_app1 appNameMetricsEnabled=false dbNameMetricsEnabled=false
+----
+value=3.000000
+
+
+sql_counter appName=test_app2 appNameMetricsEnabled=true dbNameMetricsEnabled=false
+----
+app_name=test_app2
+value=4.000000
+
+
+sql_counter appName=test_app3 appNameMetricsEnabled=true dbNameMetricsEnabled=true
+----
+db_name=defaultdb
+app_name=test_app3
+value=4.000000
+
+
+sql_counter appName=test_app4 appNameMetricsEnabled=false dbNameMetricsEnabled=true
+----
+db_name=defaultdb
+value=4.000000

--- a/pkg/util/metric/aggmetric/BUILD.bazel
+++ b/pkg/util/metric/aggmetric/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_gogo_protobuf//proto",
-        "@com_github_google_btree//:btree",
         "@com_github_prometheus_client_model//go",
     ],
 )


### PR DESCRIPTION
This commit introduces a new `SQLCounter` type, a wrapper around the `AggCounter` from the `aggmetric` package. This metric type helps manage labels added to SQL metrics based on cluster settings.

Two new cluster settings added:
- `sql.application_name_metrics.enabled` - enables `app_name` label
- `sql.db_name_metrics.enabled` - enables `db_name` label

When enabled, these settings add `app_name` and `db_name` labels to SQL metrics of type `SQLCounter`, allowing tracking of metrics by application and database.

This commit also implements the `SetOnChange` mechanism for these cluster settings, ensuring metrics are automatically redeclared with relevant labels when settings change.

Epic: CRDB-43153
Jira: CRDB-48253
Release note: None